### PR TITLE
Added accountKey field to Transaction List V2

### DIFF
--- a/.github/workflows/pypi-publish.yaml
+++ b/.github/workflows/pypi-publish.yaml
@@ -1,8 +1,9 @@
 name: Manually Publish Python Package to PyPI
+
 on:
-  push:
-    branches:
-      - main
+  release:
+    types: [ released ]
+
   workflow_dispatch:
     inputs:
       version:

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,7 +14,7 @@ cffi==1.17.1
 charset-normalizer==3.3.2
 click==8.1.7
 ConfigArgParse==1.5.3
-cryptography==43.0.1
+cryptography==44.0.1
 cycler==0.11.0
 cytoolz==0.12.2
 docutils==0.21.2

--- a/safeheron_api_sdk_python/api/transaction_api.py
+++ b/safeheron_api_sdk_python/api/transaction_api.py
@@ -65,6 +65,8 @@ class ListTransactionsV2Request:
         self.destinationAccountKey = None
         # Destination account type
         self.destinationAccountType = None
+        # The unique identifier key of a wallet account, used to query all transactions under that wallet. This is only supported for VAULT_ACCOUNT type wallets. This has a higher priority than sourceAccountKey, sourceAccountType, destinationAccountKey, destinationAccountType, and realDestinationAccountType. If accountKey is passed along with the five parameters mentioned above, only accountKey will be effective
+        self.accountKey = None
         # Start time for creating a transaction, UNIX timestamp (ms)
         self.createTimeMin = None
         # End time for creating a transaction, UNIX timestamp (ms)

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import find_packages
 with open("README.rst", "r") as f:
     long_description = f.read()
 setup(name='safeheron_api_sdk_python',
-      version='1.1.18',
+      version='1.1.19',
       description='Python for Safeheron API',
       long_description=long_description,
       author='safeheron',


### PR DESCRIPTION
Added a new field to `safeheron_api_sdk_python.api.transaction_api.ListTransactionsV2Request` in the Transaction List V2 request:
* accountKey: This field is used to query all transactions under that wallet are fully backward-compatible.